### PR TITLE
Qa updates

### DIFF
--- a/NHLBI_BioData_Catalyst/R/0_Export_from_UI.ipynb
+++ b/NHLBI_BioData_Catalyst/R/0_Export_from_UI.ipynb
@@ -132,7 +132,6 @@
     "# save the data as a dataframe\n",
     "results <- bdc::query.getResults(authPicSure, queryID)\n",
     "results <- read.delim(textConnection(results), sep = \",\")\n",
-    "colnames(results) <- results[1,]\n",
     "\n",
     "# view the first few records\n",
     "head(results)"

--- a/NHLBI_BioData_Catalyst/R/1_PICSURE_API_101.ipynb
+++ b/NHLBI_BioData_Catalyst/R/1_PICSURE_API_101.ipynb
@@ -707,43 +707,6 @@
    "source": [
     "Now your query is set to select only variables and participants from the phs accession and consent code you selected. From here, you can build out your query as shown above."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Retrieving data from a query built in the PIC-SURE user interface (UI)\n",
-    "\n",
-    "You are able to retrieve the results of a query that you have previously built using the [PIC-SURE Authorized Access UI](https://picsure.biodatacatalyst.nhlbi.nih.gov/psamaui/). After you have built your query and filtered to your cohort of interest, open the **Select and Package Data** tool in the Tool Suite. This will allow you to copy your query ID and bring it in to a Jupyter notebook. **Note that query IDs are not permanent and may expire.**\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"https://drive.google.com/uc?id=1XD3L0obdgQZ3GgO2Xu-sxhMxzzXgqofL\">"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# To run this using your notebook you must replace it with the ID value of a query that you have run.\n",
-    "query_id <- '<<<Paste your Query ID here>>>'\n",
-    "results <- bdc::query.getResults(authPicSure, query_id)\n",
-    "results <- read.delim(textConnection(results), sep = \",\")\n",
-    "colnames(results) <- results[1,]\n",
-    "head(results)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/NHLBI_BioData_Catalyst/README.md
+++ b/NHLBI_BioData_Catalyst/README.md
@@ -53,6 +53,7 @@ To get your token, process as follows:
 ## Available notebooks
 
 Example Jupyter notebooks are available in python and R. Additionally, R Markdown examples are available for RStudio environments. In the R, python, and RStudio folders, six notebooks are available:
+- 0_Export_from_UI.ipynb: A tutorial on how to export a dataframe built in the UI into an analysis workspace.
 - 1_PICSURE_API_101: An illustration of the main functionalities of the PIC-SURE API.
 - 2_PheWAS: A straightforward PIC-SURE API use-case, using a PheWAS (Phenome-Wide Association Study) analysis as an illustration example.
 - 3_HarmonizedVariables_analysis: An example of how to access and work with the "harmonized variables" across the TOPMed studies.
@@ -60,6 +61,7 @@ Example Jupyter notebooks are available in python and R. Additionally, R Markdow
 - 5_LongitudinalData: An example of how to find longitudinal variables in the data dictionary, use these variables to extract data, and perform analysis. 
 - 6_Sickle_Cell: An example on how to search and query the Hematopoietic Cell Transplant for Sickle Cell Disease (HCT for SCD) dataset.
 - 7_Harmonization_with_PICSURE: Examples of harmonization across studies using (1) sex and BMI variables (including TOPMed Harmonized dataset and others) and (2) orthopnea and pneumonia variables.
+- ORCHID (COVID19): the code accompanying the JAMA publication on November 7th 2021: "[Effect of Hydroxychloroquine on Clinical Status at 14 Days in Hospitalized Patients With COVID-19](https://jamanetwork.com/journals/jama/fullarticle/2772922)"
 
 ## Contact
 

--- a/NHLBI_BioData_Catalyst/python/ORCHID_COVID19_python.ipynb
+++ b/NHLBI_BioData_Catalyst/python/ORCHID_COVID19_python.ipynb
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "id": "c7cd643a-e3ff-4857-807a-e1c610d1ffa0",
    "metadata": {},
    "outputs": [],
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "id": "90aa8455-9f24-4f96-a0cf-e2d3e130cfd6",
    "metadata": {},
    "outputs": [
@@ -138,14 +138,14 @@
      "output_type": "stream",
      "text": [
       "Collecting git+https://github.com/hms-dbmi/pic-sure-python-client.git\n",
-      "  Cloning https://github.com/hms-dbmi/pic-sure-python-client.git to /tmp/pip-req-build-0a4tyyvb\n",
-      "  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-python-client.git /tmp/pip-req-build-0a4tyyvb\n",
+      "  Cloning https://github.com/hms-dbmi/pic-sure-python-client.git to /tmp/pip-req-build-ljf6ndad\n",
+      "  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-python-client.git /tmp/pip-req-build-ljf6ndad\n",
       "  Resolved https://github.com/hms-dbmi/pic-sure-python-client.git to commit aabcc6574eede2dc3de410c6c75f7f77ea18d23c\n",
       "  Preparing metadata (setup.py) ... \u001b[?25ldone\n",
       "\u001b[?25hBuilding wheels for collected packages: PicSureClient\n",
       "  Building wheel for PicSureClient (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for PicSureClient: filename=PicSureClient-0.1.0-py2.py3-none-any.whl size=10309 sha256=9028bb69ff45ab64b687de9bbcd6814a1d342630b3a19a4bfeed27f57d27aa7a\n",
-      "  Stored in directory: /tmp/pip-ephem-wheel-cache-j1k0hvpp/wheels/90/65/c4/e74447484bdae71b64f3f0a500bc7b3d9d6ee7edc62ade6667\n",
+      "\u001b[?25h  Created wheel for PicSureClient: filename=PicSureClient-0.1.0-py2.py3-none-any.whl size=10309 sha256=2a980ca44b5e321c37444963e106b5cc93633325ef75c003adfdf7e9676a126e\n",
+      "  Stored in directory: /tmp/pip-ephem-wheel-cache-btm8p94w/wheels/90/65/c4/e74447484bdae71b64f3f0a500bc7b3d9d6ee7edc62ade6667\n",
       "Successfully built PicSureClient\n",
       "Installing collected packages: PicSureClient\n",
       "  Attempting uninstall: PicSureClient\n",
@@ -154,8 +154,8 @@
       "      Successfully uninstalled PicSureClient-0.1.0\n",
       "Successfully installed PicSureClient-0.1.0\n",
       "Collecting git+https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git\n",
-      "  Cloning https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git to /tmp/pip-req-build-oxjr1fxn\n",
-      "  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git /tmp/pip-req-build-oxjr1fxn\n",
+      "  Cloning https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git to /tmp/pip-req-build-jdcrleit\n",
+      "  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git /tmp/pip-req-build-jdcrleit\n",
       "  Resolved https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git to commit 7b5c4b3fd544be200adaf50b17e4e7d6af5778fb\n",
       "  Preparing metadata (setup.py) ... \u001b[?25ldone\n",
       "\u001b[?25hCollecting httplib2\n",
@@ -164,8 +164,8 @@
       "  Using cached pyparsing-3.0.9-py3-none-any.whl (98 kB)\n",
       "Building wheels for collected packages: PicSureHpdsLib\n",
       "  Building wheel for PicSureHpdsLib (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for PicSureHpdsLib: filename=PicSureHpdsLib-0.9.0-py2.py3-none-any.whl size=22057 sha256=116000e00fea4d7eb12b05bc12c67b35a4ff44688da32098e600566df9121d41\n",
-      "  Stored in directory: /tmp/pip-ephem-wheel-cache-idjx8enp/wheels/75/32/ca/ca45a25b13de6d9ec7a4d584241d588f730f81fadf580ff34d\n",
+      "\u001b[?25h  Created wheel for PicSureHpdsLib: filename=PicSureHpdsLib-0.9.0-py2.py3-none-any.whl size=22057 sha256=0e500cc4af880def6340b7fbb96ebc6219991064ed1216a83777181e7394127d\n",
+      "  Stored in directory: /tmp/pip-ephem-wheel-cache-y3rm6tzd/wheels/75/32/ca/ca45a25b13de6d9ec7a4d584241d588f730f81fadf580ff34d\n",
       "Successfully built PicSureHpdsLib\n",
       "Installing collected packages: pyparsing, httplib2, PicSureHpdsLib\n",
       "  Attempting uninstall: pyparsing\n",
@@ -181,13 +181,10 @@
       "    Uninstalling PicSureHpdsLib-0.9.0:\n",
       "      Successfully uninstalled PicSureHpdsLib-0.9.0\n",
       "Successfully installed PicSureHpdsLib-0.9.0 httplib2-0.20.4 pyparsing-3.0.9\n",
-      "Collecting git+https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git@new-search\n",
-      "  Cloning https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git (to revision new-search) to /tmp/pip-req-build-uq_451i1\n",
-      "  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git /tmp/pip-req-build-uq_451i1\n",
-      "  Running command git checkout -b new-search --track origin/new-search\n",
-      "  Switched to a new branch 'new-search'\n",
-      "  Branch 'new-search' set up to track remote branch 'new-search' from 'origin'.\n",
-      "  Resolved https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git to commit 83a4c563920c407aac1b643c29f65a4b54c962a5\n",
+      "Collecting git+https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git\n",
+      "  Cloning https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git to /tmp/pip-req-build-mvim8cn4\n",
+      "  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git /tmp/pip-req-build-mvim8cn4\n",
+      "  Resolved https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git to commit 3ae21808acd3d6854d01ba57e2c513ef0e8f755d\n",
       "  Preparing metadata (setup.py) ... \u001b[?25ldone\n",
       "\u001b[?25hCollecting httplib2\n",
       "  Using cached httplib2-0.20.4-py3-none-any.whl (96 kB)\n",
@@ -195,8 +192,8 @@
       "  Using cached pyparsing-3.0.9-py3-none-any.whl (98 kB)\n",
       "Building wheels for collected packages: PicSureBdcAdapter\n",
       "  Building wheel for PicSureBdcAdapter (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for PicSureBdcAdapter: filename=PicSureBdcAdapter-1.0.0-py3-none-any.whl size=12830 sha256=2c193c1ddd9c9737e0ebe428478eeb256b5f6bdbcae0cb55cc0e4af752950fe5\n",
-      "  Stored in directory: /tmp/pip-ephem-wheel-cache-_kiphl9b/wheels/92/f8/96/fd81f60c9189f43d65ede7284408a8283b4bbf30dea39e5c96\n",
+      "\u001b[?25h  Created wheel for PicSureBdcAdapter: filename=PicSureBdcAdapter-1.0.0-py3-none-any.whl size=12830 sha256=cdac9323d9b35abbb131e4fcd50aeeccd754bb53e81fd3c21c09afccef0096ab\n",
+      "  Stored in directory: /tmp/pip-ephem-wheel-cache-8i3mk6ze/wheels/e4/3c/b0/64cb444206d84ce321e561c3fdd04f9803f4798c9d759f48e7\n",
       "Successfully built PicSureBdcAdapter\n",
       "Installing collected packages: pyparsing, httplib2, PicSureBdcAdapter\n",
       "  Attempting uninstall: pyparsing\n",
@@ -218,13 +215,12 @@
    "source": [
     "!{sys.executable} -m pip install --upgrade --force-reinstall git+https://github.com/hms-dbmi/pic-sure-python-client.git\n",
     "!{sys.executable} -m pip install --upgrade --force-reinstall git+https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git\n",
-    "!{sys.executable} -m pip install --upgrade --force-reinstall git+https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git@new-search\n",
-    "# !{sys.executable} -m pip install --upgrade --force-reinstall git+https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git"
+    "!{sys.executable} -m pip install --upgrade --force-reinstall git+https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "id": "5efa8e82-a5dd-464e-831d-27371fd3fae9",
    "metadata": {},
    "outputs": [],
@@ -243,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 13,
    "id": "f8bb8f92",
    "metadata": {},
    "outputs": [
@@ -263,9 +259,7 @@
     }
    ],
    "source": [
-    "# Uncomment production URL when testing in production\n",
-    "# PICSURE_network_URL = \"https://picsure.biodatacatalyst.nhlbi.nih.gov/picsure\"\n",
-    "PICSURE_network_URL = \"https://biodatacatalyst.integration.hms.harvard.edu/picsure\"\n",
+    "PICSURE_network_URL = \"https://picsure.biodatacatalyst.nhlbi.nih.gov/picsure\"\n",
     "token_file = \"token.txt\"\n",
     "\n",
     "with open(token_file, \"r\") as f:\n",
@@ -284,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 14,
    "id": "fd0a71f0",
    "metadata": {},
    "outputs": [],
@@ -315,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 15,
    "id": "bd2c7165",
    "metadata": {},
    "outputs": [],
@@ -342,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 16,
    "id": "f0496293",
    "metadata": {},
    "outputs": [
@@ -632,7 +626,7 @@
        "41           labs_asth_1  Highest AST - Aspartate aminotransferase (unit..."
       ]
      },
-     "execution_count": 7,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -699,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 17,
    "id": "f04432e5",
    "metadata": {},
    "outputs": [],
@@ -752,7 +746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "id": "b2709e8e",
    "metadata": {},
    "outputs": [],
@@ -880,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "id": "867656aa",
    "metadata": {},
    "outputs": [],
@@ -892,7 +886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 20,
    "id": "13d5f380",
    "metadata": {},
    "outputs": [],
@@ -909,7 +903,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 21,
    "id": "c589e026",
    "metadata": {},
    "outputs": [],
@@ -924,7 +918,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 22,
    "id": "cb915f1e",
    "metadata": {},
    "outputs": [],
@@ -937,7 +931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 23,
    "id": "eddea845",
    "metadata": {},
    "outputs": [],
@@ -952,7 +946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 24,
    "id": "782edebc",
    "metadata": {},
    "outputs": [],
@@ -966,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 25,
    "id": "b821870f",
    "metadata": {},
    "outputs": [],
@@ -980,7 +974,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 26,
    "id": "d50a5498",
    "metadata": {},
    "outputs": [],
@@ -990,7 +984,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 27,
    "id": "8d2acd3f",
    "metadata": {},
    "outputs": [],
@@ -1007,7 +1001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 28,
    "id": "1ef07f4d",
    "metadata": {},
    "outputs": [],
@@ -1021,7 +1015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 29,
    "id": "88e3d09e",
    "metadata": {},
    "outputs": [],
@@ -1035,7 +1029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 30,
    "id": "3617a11b",
    "metadata": {},
    "outputs": [
@@ -1344,7 +1338,7 @@
        "                  Chronic Obstructive Pulmonary Disease Chronic Obstructive Pulmonary Disease                  21.0  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1379,7 +1373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 31,
    "id": "93caa8ba",
    "metadata": {},
    "outputs": [],
@@ -1397,7 +1391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 32,
    "id": "70e52dff",
    "metadata": {},
    "outputs": [],
@@ -1413,7 +1407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 33,
    "id": "69950785",
    "metadata": {},
    "outputs": [],
@@ -1425,7 +1419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 34,
    "id": "04af551d",
    "metadata": {},
    "outputs": [],
@@ -1437,7 +1431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 35,
    "id": "817c5191",
    "metadata": {},
    "outputs": [],
@@ -1459,7 +1453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 36,
    "id": "ca766217",
    "metadata": {},
    "outputs": [],
@@ -1478,7 +1472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 37,
    "id": "a46f4d02",
    "metadata": {},
    "outputs": [
@@ -1518,22 +1512,6 @@
     "plt.title(title)\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "26c6afdc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11aa115f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Non-showstopper updates found during QA of the new search updates in production
- Python ORCHID: remove integration URL and uncomment production URL
- R Export: Remove a line to display correct dataframe colnames(results) <- results[1,]
- R 101: Remove export via UI portion