### PR TITLE
Regex changes for variables

### DIFF
--- a/NHLBI_BioData_Catalyst/python/8_RECOVER.ipynb
+++ b/NHLBI_BioData_Catalyst/python/8_RECOVER.ipynb
@@ -178,7 +178,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As shown above, there are derived PASC scores at different times during the data collection, indicated by `months past index date` in the description. Let's use the 0, 3, 6, and 9 months past index date variables. We will use data from `infected` participants. "
+    "As shown above, there are derived PASC scores at different times during the data collection, indicated by `months past index date` in the description. Let's use the 0, 3, 6, and 9 months past index date variables. We will use data from `infected` participants. \n",
+    "\n",
+    "*Note: The `$` is used as part of regular expression (regex), indicating that it should match the end of the string.*"
    ]
   },
   {
@@ -188,10 +190,10 @@
    "outputs": [],
    "source": [
     "# Save PASC variables for baseline and first three followups\n",
-    "pasc_0 = biostats_pasc_vars.HPDS_PATH[biostats_pasc_vars.varId.str.contains(\"_infected_0\")].values[0]\n",
-    "pasc_3 = biostats_pasc_vars.HPDS_PATH[biostats_pasc_vars.varId.str.contains(\"_infected_3\")].values[0]\n",
-    "pasc_6 = biostats_pasc_vars.HPDS_PATH[biostats_pasc_vars.varId.str.contains(\"_infected_6\")].values[0]\n",
-    "pasc_9 = biostats_pasc_vars.HPDS_PATH[biostats_pasc_vars.varId.str.contains(\"_infected_9\")].values[0]"
+    "pasc_0 = biostats_pasc_vars.HPDS_PATH[biostats_pasc_vars.varId.str.contains(\"_infected_0$\")].values[0]\n",
+    "pasc_3 = biostats_pasc_vars.HPDS_PATH[biostats_pasc_vars.varId.str.contains(\"_infected_3$\")].values[0]\n",
+    "pasc_6 = biostats_pasc_vars.HPDS_PATH[biostats_pasc_vars.varId.str.contains(\"_infected_6$\")].values[0]\n",
+    "pasc_9 = biostats_pasc_vars.HPDS_PATH[biostats_pasc_vars.varId.str.contains(\"_infected_9$\")].values[0]"
    ]
   },
   {
@@ -236,7 +238,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As shown above, there are derived head pain now scores at different times during the data collection. Let's use the 0, 3, 6, and 9 months past index date information for infected participants."
+    "As shown above, there are derived head pain now scores at different times during the data collection. Let's use the 0, 3, 6, and 9 months past index date information for infected participants.\n",
+    "\n",
+    "*Note: The `$` is used as part of regular expression (regex), indicating that it should match the end of the string.*"
    ]
   },
   {
@@ -246,10 +250,10 @@
    "outputs": [],
    "source": [
     "# Save head pain variables for baseline and first three followups\n",
-    "headpain_0 = headpain_now_vars.HPDS_PATH[headpain_now_vars.varId.str.contains(\"_infected_0\")].values[0]\n",
-    "headpain_3 = headpain_now_vars.HPDS_PATH[headpain_now_vars.varId.str.contains(\"_infected_3\")].values[0]\n",
-    "headpain_6 = headpain_now_vars.HPDS_PATH[headpain_now_vars.varId.str.contains(\"_infected_6\")].values[0]\n",
-    "headpain_9 = headpain_now_vars.HPDS_PATH[headpain_now_vars.varId.str.contains(\"_infected_9\")].values[0]"
+    "headpain_0 = headpain_now_vars.HPDS_PATH[headpain_now_vars.varId.str.contains(\"_infected_0$\")].values[0]\n",
+    "headpain_3 = headpain_now_vars.HPDS_PATH[headpain_now_vars.varId.str.contains(\"_infected_3$\")].values[0]\n",
+    "headpain_6 = headpain_now_vars.HPDS_PATH[headpain_now_vars.varId.str.contains(\"_infected_6$\")].values[0]\n",
+    "headpain_9 = headpain_now_vars.HPDS_PATH[headpain_now_vars.varId.str.contains(\"_infected_9$\")].values[0]"
    ]
   },
   {
@@ -361,18 +365,11 @@
     "plt.xlabel(\"Visit\")\n",
     "plt.title(\"RECOVER Adult PASC and Headpain of Infected Participants\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -386,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/NHLBI_BioData_Catalyst/python/8_RECOVER_executed.html
+++ b/NHLBI_BioData_Catalyst/python/8_RECOVER_executed.html
@@ -14682,77 +14682,63 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
 <pre>Collecting git+https://github.com/hms-dbmi/pic-sure-python-client.git
-  Cloning https://github.com/hms-dbmi/pic-sure-python-client.git to /tmp/pip-req-build-l2nl70zm
-  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-python-client.git /tmp/pip-req-build-l2nl70zm
+  Cloning https://github.com/hms-dbmi/pic-sure-python-client.git to /tmp/pip-req-build-7mpjvwys
+  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-python-client.git /tmp/pip-req-build-7mpjvwys
   Resolved https://github.com/hms-dbmi/pic-sure-python-client.git to commit 8cd1d3d89e8539baf972dee96dc00d88e4853004
   Preparing metadata (setup.py) ... done
 Building wheels for collected packages: PicSureClient
   Building wheel for PicSureClient (setup.py) ... done
-  Created wheel for PicSureClient: filename=PicSureClient-0.1.0-py2.py3-none-any.whl size=10726 sha256=0de676042133b12947c5a8850733e64920605ad153373dbccb6df53bfd748915
-  Stored in directory: /tmp/pip-ephem-wheel-cache-0euhy94h/wheels/90/65/c4/e74447484bdae71b64f3f0a500bc7b3d9d6ee7edc62ade6667
+  Created wheel for PicSureClient: filename=PicSureClient-0.1.0-py2.py3-none-any.whl size=10726 sha256=6aa29b1fb17f0de3f0ce6080759c5565868427452da87e0f5144d3d686b2fe29
+  Stored in directory: /tmp/pip-ephem-wheel-cache-4apkuipr/wheels/90/65/c4/e74447484bdae71b64f3f0a500bc7b3d9d6ee7edc62ade6667
 Successfully built PicSureClient
 Installing collected packages: PicSureClient
-  Attempting uninstall: PicSureClient
-    Found existing installation: PicSureClient 0.1.0
-    Uninstalling PicSureClient-0.1.0:
-      Successfully uninstalled PicSureClient-0.1.0
 Successfully installed PicSureClient-0.1.0
 Collecting git+https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git
-  Cloning https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git to /tmp/pip-req-build-mcxt7aam
-  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git /tmp/pip-req-build-mcxt7aam
+  Cloning https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git to /tmp/pip-req-build-7hgdf_ka
+  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git /tmp/pip-req-build-7hgdf_ka
   Resolved https://github.com/hms-dbmi/pic-sure-python-adapter-hpds.git to commit 696907e7ea18e2d3b511b50a355df27ea869d4a7
   Preparing metadata (setup.py) ... done
 Collecting httplib2
-  Using cached httplib2-0.31.0-py3-none-any.whl (91 kB)
-Collecting pyparsing&lt;4,&gt;=3.0.4
-  Using cached pyparsing-3.2.5-py3-none-any.whl (113 kB)
+  Downloading httplib2-0.31.2-py3-none-any.whl (91 kB)
+     <span class="ansi-black-intense-fg">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span class="ansi-green-fg">91.1/91.1 kB</span> <span class="ansi-red-fg">13.9 MB/s</span> eta <span class="ansi-cyan-fg">0:00:00</span>
+Collecting pyparsing&lt;4,&gt;=3.1
+  Downloading pyparsing-3.3.2-py3-none-any.whl (122 kB)
+     <span class="ansi-black-intense-fg">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span class="ansi-green-fg">122.8/122.8 kB</span> <span class="ansi-red-fg">24.8 MB/s</span> eta <span class="ansi-cyan-fg">0:00:00</span>
 Building wheels for collected packages: PicSureHpdsLib
   Building wheel for PicSureHpdsLib (setup.py) ... done
-  Created wheel for PicSureHpdsLib: filename=PicSureHpdsLib-0.9.0-py2.py3-none-any.whl size=22162 sha256=a139063ff1b12badb3a2698a1c0ce0121f79fa7f737244a126053a46790c62e1
-  Stored in directory: /tmp/pip-ephem-wheel-cache-sybntq1s/wheels/75/32/ca/ca45a25b13de6d9ec7a4d584241d588f730f81fadf580ff34d
+  Created wheel for PicSureHpdsLib: filename=PicSureHpdsLib-0.9.0-py2.py3-none-any.whl size=22162 sha256=442f6c04970ba21e94f8c3519d3f6abfb6b97ed4940b08c725a43c2664930339
+  Stored in directory: /tmp/pip-ephem-wheel-cache-qfwv3_ae/wheels/75/32/ca/ca45a25b13de6d9ec7a4d584241d588f730f81fadf580ff34d
 Successfully built PicSureHpdsLib
 Installing collected packages: pyparsing, httplib2, PicSureHpdsLib
   Attempting uninstall: pyparsing
-    Found existing installation: pyparsing 3.2.5
-    Uninstalling pyparsing-3.2.5:
-      Successfully uninstalled pyparsing-3.2.5
-  Attempting uninstall: httplib2
-    Found existing installation: httplib2 0.31.0
-    Uninstalling httplib2-0.31.0:
-      Successfully uninstalled httplib2-0.31.0
-  Attempting uninstall: PicSureHpdsLib
-    Found existing installation: PicSureHpdsLib 0.9.0
-    Uninstalling PicSureHpdsLib-0.9.0:
-      Successfully uninstalled PicSureHpdsLib-0.9.0
-Successfully installed PicSureHpdsLib-0.9.0 httplib2-0.31.0 pyparsing-3.2.5
+    Found existing installation: pyparsing 3.0.9
+    Uninstalling pyparsing-3.0.9:
+      Successfully uninstalled pyparsing-3.0.9
+Successfully installed PicSureHpdsLib-0.9.0 httplib2-0.31.2 pyparsing-3.3.2
 Collecting git+https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git
-  Cloning https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git to /tmp/pip-req-build-2oq6hyuv
-  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git /tmp/pip-req-build-2oq6hyuv
-  Resolved https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git to commit f696156b2e798606920303decb8fcf894231efd3
+  Cloning https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git to /tmp/pip-req-build-o9iu68zu
+  Running command git clone --filter=blob:none --quiet https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git /tmp/pip-req-build-o9iu68zu
+  Resolved https://github.com/hms-dbmi/pic-sure-biodatacatalyst-python-adapter-hpds.git to commit 4ae6757b1880341aa4c06838fd3dbf3a86db9d6a
   Preparing metadata (setup.py) ... done
 Collecting httplib2
-  Using cached httplib2-0.31.0-py3-none-any.whl (91 kB)
-Collecting pyparsing&lt;4,&gt;=3.0.4
-  Using cached pyparsing-3.2.5-py3-none-any.whl (113 kB)
+  Using cached httplib2-0.31.2-py3-none-any.whl (91 kB)
+Collecting pyparsing&lt;4,&gt;=3.1
+  Using cached pyparsing-3.3.2-py3-none-any.whl (122 kB)
 Building wheels for collected packages: PicSureBdcAdapter
   Building wheel for PicSureBdcAdapter (setup.py) ... done
-  Created wheel for PicSureBdcAdapter: filename=PicSureBdcAdapter-1.0.0-py3-none-any.whl size=12830 sha256=9c3042610860f8b2be45c89593894379e4a603940a717a707cae8f4d7f19ec14
-  Stored in directory: /tmp/pip-ephem-wheel-cache-rz5ycurd/wheels/e4/3c/b0/64cb444206d84ce321e561c3fdd04f9803f4798c9d759f48e7
+  Created wheel for PicSureBdcAdapter: filename=PicSureBdcAdapter-1.0.0-py3-none-any.whl size=12934 sha256=1cc5d3a8cbc5755a986baa9a538468685292030428a9446fa0990f169e48d7dc
+  Stored in directory: /tmp/pip-ephem-wheel-cache-95r66vus/wheels/e4/3c/b0/64cb444206d84ce321e561c3fdd04f9803f4798c9d759f48e7
 Successfully built PicSureBdcAdapter
 Installing collected packages: pyparsing, httplib2, PicSureBdcAdapter
   Attempting uninstall: pyparsing
-    Found existing installation: pyparsing 3.2.5
-    Uninstalling pyparsing-3.2.5:
-      Successfully uninstalled pyparsing-3.2.5
+    Found existing installation: pyparsing 3.3.2
+    Uninstalling pyparsing-3.3.2:
+      Successfully uninstalled pyparsing-3.3.2
   Attempting uninstall: httplib2
-    Found existing installation: httplib2 0.31.0
-    Uninstalling httplib2-0.31.0:
-      Successfully uninstalled httplib2-0.31.0
-  Attempting uninstall: PicSureBdcAdapter
-    Found existing installation: PicSureBdcAdapter 1.0.0
-    Uninstalling PicSureBdcAdapter-1.0.0:
-      Successfully uninstalled PicSureBdcAdapter-1.0.0
-Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
+    Found existing installation: httplib2 0.31.2
+    Uninstalling httplib2-0.31.2:
+      Successfully uninstalled httplib2-0.31.2
+Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.2 pyparsing-3.3.2
 </pre>
 </div>
 </div>
@@ -14835,6 +14821,7 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
 <pre>+--------------------------------------+------------------------------------------------------+
 |  Resource UUID                       |  Resource Name                                       |
 +--------------------------------------+------------------------------------------------------+
+| ac004461-1b47-4832-80e2-22a4aecabe39 | open-hpds-v3                                         |
 | ca0ad4a9-130a-3a8a-ae00-e35b07f1108b | visualization                                        |
 | 02e23f52-f354-4e8b-992c-d37c8b9ba140 | auth-hpds                                            |
 | 36363664-6231-6134-2d38-6538652d3131 | dictionary                                           |
@@ -14964,120 +14951,120 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
     <tr>
       <th>0</th>
       <td>phs003463</td>
-      <td>Inf</td>
-      <td>rc-ra1:ps_colldt|inf|v0</td>
+      <td>infected</td>
+      <td>pasc_pg2023_infected_63</td>
       <td>True</td>
       <td>False</td>
-      <td>[2021-01-01, 2021-01-02, 2021-01-03, 2021-01-0...</td>
+      <td>[No PASC, PASC]</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-00...</td>
-      <td>Answerdata Form: pasc_symptoms Field: ps_colld...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
+      <td>Participants are infected and 63 months past i...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-00...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>Inf</td>
-      <td>Inf</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>infected</td>
+      <td>infected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\visi...</td>
       <td>NaN</td>
       <td>NaN</td>
     </tr>
     <tr>
       <th>1</th>
       <td>phs003463</td>
-      <td>Inf</td>
-      <td>rc-ra1:ps_colldt|inf|v3</td>
+      <td>infected</td>
+      <td>pasc_pg2023_infected_3</td>
       <td>True</td>
       <td>False</td>
-      <td>[2021-01-01, 2021-01-03, 2021-01-22, 2021-01-2...</td>
+      <td>[No PASC, PASC]</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-03...</td>
-      <td>Answerdata Form: pasc_symptoms Field: ps_colld...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
+      <td>Participants are infected and 3 months past in...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-03...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>Inf</td>
-      <td>Inf</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>infected</td>
+      <td>infected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\visi...</td>
       <td>NaN</td>
       <td>NaN</td>
     </tr>
     <tr>
       <th>2</th>
       <td>phs003463</td>
-      <td>Inf</td>
-      <td>rc-ra1:ps_colldt|inf|v6</td>
+      <td>infected</td>
+      <td>pasc_pg2023_infected_51</td>
       <td>True</td>
       <td>False</td>
-      <td>[2021-01-03, 2021-03-05, 2021-03-18, 2021-03-2...</td>
+      <td>[No PASC, PASC]</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-06...</td>
-      <td>Answerdata Form: pasc_symptoms Field: ps_colld...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
+      <td>Participants are infected and 51 months past i...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-06...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>Inf</td>
-      <td>Inf</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>infected</td>
+      <td>infected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\visi...</td>
       <td>NaN</td>
       <td>NaN</td>
     </tr>
     <tr>
       <th>3</th>
       <td>phs003463</td>
-      <td>Inf</td>
-      <td>rc-ra1:ps_colldt|inf|v9</td>
+      <td>infected</td>
+      <td>pasc_pg2023_infected_45</td>
       <td>True</td>
       <td>False</td>
-      <td>[2021-01-01, 2021-01-02, 2021-03-19, 2021-05-0...</td>
+      <td>[No PASC, PASC]</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-09...</td>
-      <td>Answerdata Form: pasc_symptoms Field: ps_colld...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
+      <td>Participants are infected and 45 months past i...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-09...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>Inf</td>
-      <td>Inf</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>infected</td>
+      <td>infected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\visi...</td>
       <td>NaN</td>
       <td>NaN</td>
     </tr>
     <tr>
       <th>4</th>
       <td>phs003463</td>
-      <td>Inf</td>
-      <td>rc-ra1:ps_colldt|inf|v12</td>
+      <td>infected</td>
+      <td>pasc_pg2023_infected_33</td>
       <td>True</td>
       <td>False</td>
-      <td>[2021-01-01, 2021-01-02, 2021-01-03, 2021-01-0...</td>
+      <td>[No PASC, PASC]</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-12...</td>
-      <td>Answerdata Form: pasc_symptoms Field: ps_colld...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
+      <td>Participants are infected and 33 months past i...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
       <td>false</td>
-      <td>Date of PASC Symptoms collection: [Infected-12...</td>
+      <td>pasc_pg2023 (Biostats Derived Visits infected,...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>Inf</td>
-      <td>Inf</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>infected</td>
+      <td>infected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\visi...</td>
       <td>NaN</td>
       <td>NaN</td>
     </tr>
@@ -15181,44 +15168,20 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
   </thead>
   <tbody>
     <tr>
-      <th>11151</th>
-      <td>phs003463</td>
-      <td>infected</td>
-      <td>pasc_jama2024_infected_0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>[PASC, PASC Indeterminate]</td>
-      <td>true</td>
-      <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
-      <td>Participants are infected and 0 months past in...</td>
-      <td></td>
-      <td>...</td>
-      <td>phs003463</td>
-      <td>true</td>
-      <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
-      <td>RECOVER_Adult</td>
-      <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>infected</td>
-      <td>infected</td>
-      <td>\phs003463\RECOVER_Adult\biostats_derived\visi...</td>
-      <td>NaN</td>
-      <td>NaN</td>
-    </tr>
-    <tr>
-      <th>11152</th>
+      <th>135</th>
       <td>phs003463</td>
       <td>infected</td>
       <td>pasc_jama2024_infected_3</td>
       <td>True</td>
       <td>False</td>
       <td>[PASC, PASC Indeterminate]</td>
-      <td>true</td>
+      <td>false</td>
       <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
       <td>Participants are infected and 3 months past in...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
-      <td>true</td>
+      <td>false</td>
       <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
@@ -15229,20 +15192,20 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
       <td>NaN</td>
     </tr>
     <tr>
-      <th>11153</th>
+      <th>136</th>
       <td>phs003463</td>
       <td>infected</td>
-      <td>pasc_jama2024_infected_6</td>
+      <td>pasc_jama2024_infected_15</td>
       <td>True</td>
       <td>False</td>
       <td>[PASC, PASC Indeterminate]</td>
-      <td>true</td>
+      <td>false</td>
       <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
-      <td>Participants are infected and 6 months past in...</td>
+      <td>Participants are infected and 15 months past i...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
-      <td>true</td>
+      <td>false</td>
       <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
@@ -15253,20 +15216,20 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
       <td>NaN</td>
     </tr>
     <tr>
-      <th>11154</th>
+      <th>137</th>
       <td>phs003463</td>
       <td>infected</td>
-      <td>pasc_jama2024_infected_9</td>
+      <td>pasc_jama2024_infected_57</td>
       <td>True</td>
       <td>False</td>
       <td>[PASC, PASC Indeterminate]</td>
-      <td>true</td>
+      <td>false</td>
       <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
-      <td>Participants are infected and 9 months past in...</td>
+      <td>Participants are infected and 57 months past i...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
-      <td>true</td>
+      <td>false</td>
       <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
@@ -15277,20 +15240,44 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
       <td>NaN</td>
     </tr>
     <tr>
-      <th>11430</th>
+      <th>138</th>
       <td>phs003463</td>
       <td>infected</td>
-      <td>pasc_jama2024_infected_12</td>
+      <td>pasc_jama2024_infected_45</td>
       <td>True</td>
       <td>False</td>
       <td>[PASC, PASC Indeterminate]</td>
-      <td>true</td>
+      <td>false</td>
       <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
-      <td>Participants are infected and 12 months past i...</td>
+      <td>Participants are infected and 45 months past i...</td>
       <td></td>
       <td>...</td>
       <td>phs003463</td>
-      <td>true</td>
+      <td>false</td>
+      <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
+      <td>RECOVER_Adult</td>
+      <td>Researching COVID to Enhance Recovery (RECOVER...</td>
+      <td>infected</td>
+      <td>infected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\visi...</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>139</th>
+      <td>phs003463</td>
+      <td>infected</td>
+      <td>pasc_jama2024_infected_39</td>
+      <td>True</td>
+      <td>False</td>
+      <td>[PASC, PASC Indeterminate]</td>
+      <td>false</td>
+      <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
+      <td>Participants are infected and 39 months past i...</td>
+      <td></td>
+      <td>...</td>
+      <td>phs003463</td>
+      <td>false</td>
       <td>pasc_jama2024 (Biostats Derived Visits infecte...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
@@ -15320,6 +15307,7 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
 <p>As shown above, there are derived PASC scores at different times during the data collection, indicated by <code>months past index date</code> in the description. Let's use the 0, 3, 6, and 9 months past index date variables. We will use data from <code>infected</code> participants.</p>
+<p><em>Note: The <code>$</code> is used as part of regular expression (regex), indicating that it should match the end of the string.</em></p>
 
 </div>
 </div>
@@ -15333,10 +15321,10 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># Save PASC variables for baseline and first three followups</span>
-<span class="n">pasc_0</span> <span class="o">=</span> <span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_0&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-<span class="n">pasc_3</span> <span class="o">=</span> <span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_3&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-<span class="n">pasc_6</span> <span class="o">=</span> <span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_6&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-<span class="n">pasc_9</span> <span class="o">=</span> <span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_9&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<span class="n">pasc_0</span> <span class="o">=</span> <span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_0$&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<span class="n">pasc_3</span> <span class="o">=</span> <span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_3$&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<span class="n">pasc_6</span> <span class="o">=</span> <span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_6$&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<span class="n">pasc_9</span> <span class="o">=</span> <span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">biostats_pasc_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_9$&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 </pre></div>
 
      </div>
@@ -15434,124 +15422,124 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
   </thead>
   <tbody>
     <tr>
-      <th>11</th>
+      <th>232</th>
       <td>phs003463</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
-      <td>rc-ra1:hit6_severe|inf|v0</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_60</td>
       <td>True</td>
       <td>False</td>
-      <td>[Always, Never, Rarely, Sometimes, Very often]</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>Answerdata Form: pasc_symptoms Field: hit6_severe</td>
+      <td>[does not have symptom NOW at time of survey]</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
+      <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>rc-ra1:hit6_severe|inf|v0</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_60</td>
       <td>phs003463</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
     <tr>
-      <th>13</th>
+      <th>233</th>
       <td>phs003463</td>
-      <td>rc-ra1:hit6_severe|noninf|v3</td>
-      <td>rc-ra1:hit6_severe|noninf|v0</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_51</td>
       <td>True</td>
       <td>False</td>
-      <td>[Always, Never, Rarely, Sometimes, Very often]</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>Answerdata Form: pasc_symptoms Field: hit6_severe</td>
+      <td>[does not have symptom NOW at time of survey]</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
+      <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>rc-ra1:hit6_severe|noninf|v0</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_51</td>
       <td>phs003463</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>rc-ra1:hit6_severe|noninf|v3</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
     <tr>
-      <th>14</th>
+      <th>234</th>
       <td>phs003463</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_30</td>
       <td>True</td>
       <td>False</td>
-      <td>[Always, Never, Rarely, Sometimes, Very often]</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>Answerdata Form: pasc_symptoms Field: hit6_severe</td>
+      <td>[does not have symptom NOW at time of survey, ...</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
+      <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_30</td>
       <td>phs003463</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
     <tr>
-      <th>15</th>
+      <th>235</th>
       <td>phs003463</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
-      <td>rc-ra1:hit6_severe|inf|v6</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_63</td>
       <td>True</td>
       <td>False</td>
-      <td>[Always, Never, Rarely, Sometimes, Very often]</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>Answerdata Form: pasc_symptoms Field: hit6_severe</td>
+      <td>[does not have symptom NOW at time of survey]</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
+      <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>rc-ra1:hit6_severe|inf|v6</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_63</td>
       <td>phs003463</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
     <tr>
-      <th>16</th>
+      <th>236</th>
       <td>phs003463</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
-      <td>rc-ra1:hit6_severe|inf|v9</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_42</td>
       <td>True</td>
       <td>False</td>
-      <td>[Always, Never, Rarely, Sometimes, Very often]</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>Answerdata Form: pasc_symptoms Field: hit6_severe</td>
+      <td>[does not have symptom NOW at time of survey]</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
+      <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>rc-ra1:hit6_severe|inf|v9</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_42</td>
       <td>phs003463</td>
-      <td>false</td>
-      <td>When you have headaches, how often is the pain...</td>
+      <td>true</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>rc-ra1:hit6_severe|inf|v3</td>
-      <td>When you have headaches, how often is the pain...</td>
-      <td>\phs003463\RECOVER_Adult\surveys\pasc_symptoms...</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
+      <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
   </tbody>
 </table>
@@ -15652,123 +15640,123 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
   </thead>
   <tbody>
     <tr>
-      <th>437</th>
+      <th>232</th>
       <td>phs003463</td>
-      <td>infected</td>
-      <td>pain_head___now_infected_0</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_60</td>
       <td>True</td>
       <td>False</td>
-      <td>[does not have symptom NOW at time of survey, ...</td>
+      <td>[does not have symptom NOW at time of survey]</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>pain_head___now_infected_0</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_60</td>
       <td>phs003463</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>infected</td>
-      <td>infected</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
       <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
     <tr>
-      <th>438</th>
+      <th>233</th>
       <td>phs003463</td>
-      <td>infected</td>
-      <td>pain_head___now_infected_3</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_51</td>
       <td>True</td>
       <td>False</td>
-      <td>[does not have symptom NOW at time of survey, ...</td>
+      <td>[does not have symptom NOW at time of survey]</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>pain_head___now_infected_3</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_51</td>
       <td>phs003463</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>infected</td>
-      <td>infected</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
       <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
     <tr>
-      <th>439</th>
+      <th>234</th>
       <td>phs003463</td>
-      <td>infected</td>
-      <td>pain_head___now_infected_6</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_30</td>
       <td>True</td>
       <td>False</td>
       <td>[does not have symptom NOW at time of survey, ...</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>pain_head___now_infected_6</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_30</td>
       <td>phs003463</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>infected</td>
-      <td>infected</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
       <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
     <tr>
-      <th>440</th>
+      <th>235</th>
       <td>phs003463</td>
-      <td>infected</td>
-      <td>pain_head___now_infected_9</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_63</td>
       <td>True</td>
       <td>False</td>
-      <td>[does not have symptom NOW at time of survey, ...</td>
+      <td>[does not have symptom NOW at time of survey]</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>pain_head___now_infected_9</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_63</td>
       <td>phs003463</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>infected</td>
-      <td>infected</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
       <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
     <tr>
-      <th>450</th>
+      <th>236</th>
       <td>phs003463</td>
-      <td>infected</td>
-      <td>pain_head___now_infected_12</td>
+      <td>noninfected</td>
+      <td>pain_head___now_noninfected_42</td>
       <td>True</td>
       <td>False</td>
-      <td>[does not have symptom NOW at time of survey, ...</td>
+      <td>[does not have symptom NOW at time of survey]</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>Head pain/headache [at time of survey] Partici...</td>
       <td></td>
       <td>...</td>
-      <td>Categorical</td>
-      <td>pain_head___now_infected_12</td>
+      <td>categorical</td>
+      <td>pain_head___now_noninfected_42</td>
       <td>phs003463</td>
       <td>true</td>
-      <td>pain_head___now (Biostats Derived Symptoms inf...</td>
+      <td>pain_head___now (Biostats Derived Symptoms non...</td>
       <td>RECOVER_Adult</td>
       <td>Researching COVID to Enhance Recovery (RECOVER...</td>
-      <td>infected</td>
-      <td>infected</td>
+      <td>noninfected</td>
+      <td>noninfected</td>
       <td>\phs003463\RECOVER_Adult\biostats_derived\symp...</td>
     </tr>
   </tbody>
@@ -15791,6 +15779,7 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
 <p>As shown above, there are derived head pain now scores at different times during the data collection. Let's use the 0, 3, 6, and 9 months past index date information for infected participants.</p>
+<p><em>Note: The <code>$</code> is used as part of regular expression (regex), indicating that it should match the end of the string.</em></p>
 
 </div>
 </div>
@@ -15804,10 +15793,10 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># Save head pain variables for baseline and first three followups</span>
-<span class="n">headpain_0</span> <span class="o">=</span> <span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_0&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-<span class="n">headpain_3</span> <span class="o">=</span> <span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_3&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-<span class="n">headpain_6</span> <span class="o">=</span> <span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_6&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-<span class="n">headpain_9</span> <span class="o">=</span> <span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_9&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<span class="n">headpain_0</span> <span class="o">=</span> <span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_0$&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<span class="n">headpain_3</span> <span class="o">=</span> <span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_3$&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<span class="n">headpain_6</span> <span class="o">=</span> <span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_6$&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<span class="n">headpain_9</span> <span class="o">=</span> <span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">HPDS_PATH</span><span class="p">[</span><span class="n">headpain_now_vars</span><span class="o">.</span><span class="n">varId</span><span class="o">.</span><span class="n">str</span><span class="o">.</span><span class="n">contains</span><span class="p">(</span><span class="s2">&quot;_infected_9$&quot;</span><span class="p">)]</span><span class="o">.</span><span class="n">values</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 </pre></div>
 
      </div>
@@ -15865,7 +15854,7 @@ Successfully installed PicSureBdcAdapter-1.0.0 httplib2-0.31.0 pyparsing-3.2.5
 
 
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>&lt;PicSureHpdsLib.PicSureHpdsAttrListKeys.AttrListKeys at 0x7fa5c96421a0&gt;</pre>
+<pre>&lt;PicSureHpdsLib.PicSureHpdsAttrListKeys.AttrListKeys at 0x7fe788d6fac0&gt;</pre>
 </div>
 
 </div>


### PR DESCRIPTION
The lines to identify concept paths with `str.contains` were selecting unintended variables. For example, _infected_3 may select infected_33. To avoid this, regex was added to indicate end of string matching.